### PR TITLE
Fix Map server controller crashing, speed up builds for Java components

### DIFF
--- a/mirror-map/Dockerfile
+++ b/mirror-map/Dockerfile
@@ -1,14 +1,15 @@
 # Build
 FROM eclipse-temurin:21 as builder
-RUN apt update && apt upgrade -y && apt install -y maven
+RUN apt update && apt install -y maven
 WORKDIR /mirror
-COPY ./src /mirror/src
 COPY ./pom.xml /mirror/pom.xml
-RUN mvn clean package
+RUN mvn verify --fail-never
+COPY ./src /mirror/src
+RUN mvn package -DskipTests
 
 # Run
 FROM eclipse-temurin:21
 EXPOSE 8080
 WORKDIR /mirror
-COPY --from=builder /mirror/target/mirror-map-0.0.1-jar-with-dependencies.jar ./mirror-map.jar
+COPY --from=builder /mirror/target/mirror-map-*-jar-with-dependencies.jar ./mirror-map.jar
 ENTRYPOINT [ "java", "-jar", "./mirror-map.jar" ]

--- a/mirror-map/src/main/java/mirrormap/geoip/GeoIPDatabase.java
+++ b/mirror-map/src/main/java/mirrormap/geoip/GeoIPDatabase.java
@@ -53,7 +53,12 @@ public class GeoIPDatabase {
         }
         InetAddress ip = InetAddress.getByName(ipAddress);
         CityResponse response = reader.city(ip);
-        return new double[]{response.getLocation().getLatitude(), response.getLocation().getLongitude()};
+        Double latitude = response.getLocation().getLatitude();
+        Double longitude = response.getLocation().getLongitude();
+        if(latitude == null | longitude == null) {
+            throw new IOException("Failed to get latitude/longitude from GeoIP database.");
+        }
+        return new double[]{latitude, longitude};
     }
 
 }

--- a/mirror-map/src/main/java/mirrormap/geoip/GeoIPDatabase.java
+++ b/mirror-map/src/main/java/mirrormap/geoip/GeoIPDatabase.java
@@ -41,7 +41,7 @@ public class GeoIPDatabase {
         }
         catch(IOException e){
             log.error("Failed to configure GeoIP database.");
-            e.printStackTrace();
+            log.debug(e.toString());
         }
         log.info("Done configuring GeoIP database.");
     }

--- a/mirror-map/src/main/java/mirrormap/geoip/GeoIPUpdater.java
+++ b/mirror-map/src/main/java/mirrormap/geoip/GeoIPUpdater.java
@@ -51,13 +51,6 @@ public class GeoIPUpdater implements Runnable {
         //get a pointer to the maxmind handler object
         GeoIPDatabase maxmind = GeoIPDatabase.getInstance();
         while(true){
-            log.info("Updating GeoIP database...");
-            //download the database
-            downloadDatabase();
-            //configure the database handler for the database file
-            maxmind.configure();
-            log.info("Done updating GeoIP database.");
-
             try{
                 //TODO: Change to sleep till 1am (or midnight)
                 //sleep for 1 day
@@ -66,6 +59,14 @@ public class GeoIPUpdater implements Runnable {
             catch(InterruptedException e){
                 break;
             }
+            log.info("Updating GeoIP database...");
+            //download the database
+            downloadDatabase();
+            //configure the database handler for the database file
+            maxmind.configure();
+            log.info("Done updating GeoIP database.");
+
+
         }
     }
 
@@ -120,7 +121,7 @@ public class GeoIPUpdater implements Runnable {
         }
         catch(IOException | GeneralSecurityException e){
             log.error("Failed to update GeoIP database.");
-            e.printStackTrace();
+            log.debug(e.toString());
         }
     }
 

--- a/mirror-map/src/main/java/mirrormap/main/MirrorMapApplication.java
+++ b/mirror-map/src/main/java/mirrormap/main/MirrorMapApplication.java
@@ -70,10 +70,10 @@ public class MirrorMapApplication {
             }
         } catch(IOException e) {
             log.fatal("IOException while initializing map backend.");
-            e.printStackTrace();
+            log.debug(e.toString());
         } catch(ParseException e) {
             log.fatal("ParseException while initializing map backend.");
-            e.printStackTrace();
+            log.debug(e.toString());
         }
     }
 }

--- a/mirror-map/src/main/java/mirrormap/websocket/WebsocketServer.java
+++ b/mirror-map/src/main/java/mirrormap/websocket/WebsocketServer.java
@@ -42,11 +42,11 @@ public class WebsocketServer extends Thread {
                     log.error("Server socket forcibly closed.");
                     return;
                 }
-                e.printStackTrace();
+                log.debug(e.toString());
                 return;
             } catch(RejectedExecutionException e) {
                 log.error("Failed to assign websocket session to thread pool.");
-                e.printStackTrace();
+                log.debug(e.toString());
             }
         }
     }
@@ -59,7 +59,7 @@ public class WebsocketServer extends Thread {
             log.info("Closed server socket.");
         } catch(IOException e) {
             log.error("Failed to close server socket.");
-            e.printStackTrace();
+            log.debug(e.toString());
         }
     }
 }

--- a/mirrorlog/Dockerfile
+++ b/mirrorlog/Dockerfile
@@ -1,9 +1,10 @@
 FROM eclipse-temurin:21 as builder
-RUN apt update && apt upgrade -y && apt install -y maven
+RUN apt update && apt install -y maven
 WORKDIR /mirror
-COPY ./src /mirror/src
 COPY ./pom.xml /mirror/pom.xml
-RUN mvn clean package
+RUN mvn verify --fail-never
+COPY ./src /mirror/src
+RUN mvn package -DskipTests
 
 FROM eclipse-temurin:21
 EXPOSE 4001


### PR DESCRIPTION
 - Create another check in the GeoIP database utility to prevent NullPointerExceptions from crashing the Map server controller
 - Avoid unnecessarily repeating expensive tasks like downloading packages in dockerfiles for Java components