### PR TITLE
Minor fixes to website

### DIFF
--- a/mirror-website/mirror_website/static/css/style.css
+++ b/mirror-website/mirror_website/static/css/style.css
@@ -109,6 +109,7 @@ nav>a {
     transition-duration: 200ms;
     padding: 1rem 1.5rem;
     border-bottom: 1px solid transparent;
+    line-height: 1.2em;
 }
 
 nav>a:hover {
@@ -122,7 +123,8 @@ nav>a.active {
 }
 
 .navbar_spacer {
-    height: 56px;
+    height: 3.2rem;
+    border-bottom: 2px solid transparent;
 }
 
 nav>.expand_button {

--- a/mirror-website/mirror_website/templates/base.html
+++ b/mirror-website/mirror_website/templates/base.html
@@ -32,7 +32,7 @@
                 <br>
                 <br>
                 Mirror is Free and Open Source.
-                <a class="footer_link" href="#">View on Github</a>
+                <a class="footer_link" href="https://github.com/COSI-Lab/mirror">View on Github</a>
             </div>
         </footer>
     </body>


### PR DESCRIPTION
This addresses issues #23 and #21. The link at the bottom of all pages previously just linked to `#` which has now been replaced with the proper repo link. The navbar originally had a spacer behind it that was a fixed pixel size, which now uses a relative size. Because of the lack of standardization in browsers for default `line-height` to `font-size` ratio, I've used a somewhat janky solution for simplicity, and would be open to improvements.