### PR TITLE
Sync-Fix

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -51,6 +51,7 @@ services:
       - "./mirror-sync-scheduler/storage:/storage"
       - "./mirror-sync-scheduler/configs:/mirror/configs:ro"
       - "./mirror-sync-scheduler/scripts:/mirror/scripts:ro"
+      - "./mirror-sync-scheduler/secrets:/mirror/secrets:ro"
     networks:
       - mirror
     depends_on:

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -71,6 +71,8 @@ services:
       - "/storage:/storage"
       - "./configs:/mirror/configs:ro"
       - "./scripts:/mirror/scripts:ro"
+      - "./secrets:/mirror/secrets:ro"
+
     networks:
       - mirror
     depends_on:


### PR DESCRIPTION
Syncs are failing with code 10 or 30 more than they should be.

This PR aims to fix that problem as well as a few others:

- Rsync password files were being read from the wrong place
- Currently Rsync `stdout` and `stderr` are being discarded, at a minimum `stderr` should be written to a file if it contains anything to make identifying issues possible