### PR TITLE
Fix dev docker compose

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -44,7 +44,7 @@ services:
     build: ./mirror-sync-scheduler
     container_name: mirror-sync-scheduler
     env_file:
-      - configs/sync-scheduler.env
+      - mirror-sync-scheduler/configs/sync-scheduler.env
     expose:
       - 9281
     volumes:


### PR DESCRIPTION
```
sync-scheduler:
    build: ./mirror-sync-scheduler
    container_name: mirror-sync-scheduler
    env_file:
      - configs/sync-scheduler.env
 ```

`env file /home/brendanjconnelly/repos/mirror/configs/sync-scheduler.env not found: stat /home/brendanjconnelly/repos/mirror/configs/sync-scheduler.env: no such file or directory`