### PR TITLE
Decode the sync scheduler's response to a manual sync request as utf-8

### DIFF
--- a/mirror-website/mirror_website/views.py
+++ b/mirror-website/mirror_website/views.py
@@ -95,7 +95,7 @@ def sync(request: HttpRequest, project: str):
     reply = socket.recv()
     socket.close()
 
-    if str(reply.decode("utf-8")).startswith("SUCCESS"):
+    if reply.decode("utf-8").startswith("SUCCESS"):
         return HttpResponse(reply)
     else:
         return HttpResponseBadRequest(reply)

--- a/mirror-website/mirror_website/views.py
+++ b/mirror-website/mirror_website/views.py
@@ -95,7 +95,7 @@ def sync(request: HttpRequest, project: str):
     reply = socket.recv()
     socket.close()
 
-    if str(reply).startswith("SUCCESS"):
+    if str(reply.decode("utf-8")).startswith("SUCCESS"):
         return HttpResponse(reply)
     else:
         return HttpResponseBadRequest(reply)


### PR DESCRIPTION
When a manual sync is requested, the sync scheduler responds with "SUCCESS: started sync for [project name]". When Python receives this, it is a byte string. Python determines whether to return a 200 or a 400 based on the start of this string, and this checking is done improperly on a byte string.
```
>>> normal_string = 'SUCCESS'
>>> byte_string = b'SUCCESS'
>>> normal_string.startswith("SUCCESS")
True
>>> str(byte_string).startswith("SUCCESS") # Current implementation
False
>>> byte_string.decode("utf-8").startswith("SUCCESS") # New implementation
True
```